### PR TITLE
On teardown, close all sails-oracle-db connections automatically.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -118,3 +118,14 @@ utils.buildSelectStatement = function(criteria, table) {
   // Else select ALL
   return 'SELECT * FROM ' + table + ' ';
 };
+
+utils.getSailsDBConnections = function(connections) {
+  var matched = {};
+  for(var connection in connections) {
+    if(connections[connection].config.adapter === "sails-oracledb") {
+      matched[connection] = connections[connection];
+    }
+  }
+
+  return matched;
+};

--- a/package.json
+++ b/package.json
@@ -24,14 +24,15 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "oracle": "0.3.7",
     "asynk": ">=0.0.3",
+    "chai": "^2.2.0",
+    "generic-pool": "~2.1.1",
+    "oracle": "0.3.7",
     "underscore": "~1.4.3",
     "underscore.string": "~2.3.1",
-    "waterline-errors": "~0.10.0",
-    "waterline-sequel": "git://github.com/atiertant/waterline-sequel#master",
     "waterline-cursor": "~0.0.5",
-    "generic-pool": "~2.1.1"
+    "waterline-errors": "~0.10.0",
+    "waterline-sequel": "git://github.com/atiertant/waterline-sequel#master"
   },
   "devDependencies": {
     "mocha": "~1.13.0",

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -1,0 +1,33 @@
+var should = require('chai').should();
+var utils = require('../../lib/utils');
+
+describe('utils', function() {
+  describe('getSailsDBConnections', function() {
+    var sailsConnections = {
+      oracle_EODS: {
+        config: {
+          tns: '(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = 192.168.1.1)(PORT = 1522))(CONNECT_DATA =(SID = ORCL)))',
+          user: 'user',
+          password: 'pass',
+          migrate: 'safe',
+          adapter: 'sails-oracledb',
+          identity: 'oracle_EODS' }
+      },
+      mysql: {
+        config: {
+          tns: '(DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = 192.168.1.2)(PORT = 1522))(CONNECT_DATA =(SID = ORCL)))',
+          user: 'user',
+          password: 'pass',
+          migrate: 'safe',
+          adapter: 'sails-mysql',
+          identity: 'oracle_EODS'
+        }
+      }
+    };
+
+    it('should return all sails-db connection keys', function() {
+      Object.keys(utils.getSailsDBConnections(sailsConnections)).length.should.eql(1);
+      Object.keys(utils.getSailsDBConnections(sailsConnections))[0].should.eql('oracle_EODS');
+    });
+  });
+});


### PR DESCRIPTION
Upon sails.lower, the following error occurs:

TypeError: Cannot read property 'connection' of undefined
      at Object.module.exports.adapter.teardown (/home/ec2-user/.jenkins/workspace/efs-logs-activity-service/node_modules/sails-oracledb/index.js:134:51)

Apparently, the tearDown() method is being called with a null. Created a patch to automatically look for adapter "sails-oracledb" connections.
